### PR TITLE
Remove Pop-up when copying a file path

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,7 +19,6 @@ function activate(context) {
 
         filePath = editor.document.fileName.replace(vscode.workspace.rootPath + '/', '');
         statusBarItem.text = "$(checklist)   "+filePath;
-        vscode.window.showInformationMessage("Path "+filePath + " copied to clipboard");
 
         ncp.copy(filePath, function () {});
 


### PR DESCRIPTION
Depending upon how useful you guys think the popup is, I propose there could either be a way to disable it in the settings or to not trigger it entirely. 

What do you think of this? :)